### PR TITLE
Annotate uncontroled registers to maintain logic

### DIFF
--- a/analyzer/scanner/scanner.py
+++ b/analyzer/scanner/scanner.py
@@ -137,7 +137,12 @@ class Scanner:
                     bvs = claripy.BVS(reg, length, annotations=(UncontrolledAnnotation(reg),))
                 setattr(state.regs, reg, bvs)
             except AttributeError:
-                l.critical(f"Invalid register in config! {reg}")
+                l.critical(f"Invalid register in x86 arch! {reg}")
+
+        # Unknown registers in config
+        unknown_regs = [str(r) for r in global_config['controlled_registers'] if r not in get_x86_registers()]
+        if unknown_regs:
+            l.critical(f"Invalid registers in config! {', '.join(unknown_regs)}")
 
         # Attacker-controlled stack locations: save them as stores.
         # TODO: this is a hack. If STL forwarding is disabled, stack variables

--- a/analyzer/scanner/scanner.py
+++ b/analyzer/scanner/scanner.py
@@ -26,6 +26,7 @@ from ..shared.transmission import *
 from ..shared.taintedFunctionPointer import *
 from ..shared.config import *
 from ..shared.astTransform import *
+from ..shared.utils import get_x86_registers
 # autopep8: on
 
 l = get_logger("Scanner")
@@ -126,14 +127,17 @@ class Scanner:
         state.regs.gs = claripy.BVS('gs', 64, annotations=(UncontrolledAnnotation('gs'),))
 
         # Attacker-controlled registers.
-        for reg in global_config['controlled_registers']:
+        for reg in get_x86_registers():
             try:
                 length = getattr(state.regs, reg).length
+
+                if reg in global_config['controlled_registers']:
+                    bvs = claripy.BVS(reg, length, annotations=(AttackerAnnotation(reg),))
+                else:
+                    bvs = claripy.BVS(reg, length, annotations=(UncontrolledAnnotation(reg),))
+                setattr(state.regs, reg, bvs)
             except AttributeError:
                 l.critical(f"Invalid register in config! {reg}")
-
-            bvs = claripy.BVS(reg, length, annotations=(AttackerAnnotation(reg),))
-            setattr(state.regs, reg, bvs)
 
         # Attacker-controlled stack locations: save them as stores.
         # TODO: this is a hack. If STL forwarding is disabled, stack variables


### PR DESCRIPTION
Annotate uncontrolled register symbols to maintain logic that all symbols are annotated when scanning/analyzing as assumed here:
https://github.com/vusec/inspectre-gadget/blob/00b6278706322c004641d518f210c88352ce42e8/analyzer/analysis/requirementsAnalysis.py#L87