### PR TITLE
Scanner eval experiment: downgrade Ubuntu 23.04 to Ubuntu 22.04 LTS so that it works again

### DIFF
--- a/experiments/scanner-eval/Dockerfile
+++ b/experiments/scanner-eval/Dockerfile
@@ -1,22 +1,22 @@
 #
 # Prepare the environment for eval.
 #
-FROM ubuntu:23.04 AS base
+FROM ubuntu:22.04 AS base
 
 # Packages.
 RUN apt-get update && \
     apt-get install -y build-essential libncurses-dev bison flex libssl-dev \
     libelf-dev zstd qemu-system-x86 debootstrap wget bc sudo python3-pip \
-    openssh-client clang-16 git sqlite3 vim fish
+    openssh-client clang-15 git sqlite3 vim fish
 
 # Python dependencies.
 COPY inspectre /inspectre
-RUN pip3 install -r inspectre/requirements.txt --break-system-packages
-RUN pip3 install qemu.qmp --break-system-packages
+RUN PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install -r inspectre/requirements.txt
+RUN PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install qemu.qmp
 
 # Graph drawing dependencies.
-RUN pip3 install pandas matplotlib numpy cycler scienceplots tqdm argparse --break-system-packages
-RUN apt-get -y install texlive-latex-extra texlive-fonts-recommended dvipng cm-super
+RUN PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install pandas matplotlib numpy cycler scienceplots tqdm argparse
+RUN DEBIAN_FRONTEND=noninteractive TZ=Europe/Amsterdam apt-get -y install texlive-latex-extra texlive-fonts-recommended dvipng cm-super
 
 COPY vm/build /vm
 WORKDIR /vm

--- a/experiments/scanner-eval/vm/build/build-fineibt.sh
+++ b/experiments/scanner-eval/vm/build/build-fineibt.sh
@@ -2,12 +2,12 @@ set -e
 
 git apply ../fineibt_vm_support.patch
 
-make CC=clang-16 defconfig
+make CC=clang-15 defconfig
 
 echo "CONFIG_FINEIBT=y" >> .config
 echo "CONFIG_CFI_CLANG=y" >> .config
 echo "CONFIG_CONFIGFS_FS=y" >> .config
 echo "CONFIG_SECURITYFS=y" >> .config
 
-yes "n" | make CC=clang-16 oldconfig
-make CC=clang-16 -j`nproc`
+yes "n" | make CC=clang-15 oldconfig
+make CC=clang-15 -j`nproc`


### PR DESCRIPTION
Ubuntu 23.04 repositories are no longer supported, this prevents the docker container from working.
Updating to 24.04 is currently not an option as it only comes with python 12 which inspectre does not support. As such the only option is to downgrade to 22.04 which is an LTS release and is still supported.