### PR TITLE
Aggressive spec

### DIFF
--- a/analyzer/scanner/memory.py
+++ b/analyzer/scanner/memory.py
@@ -104,6 +104,10 @@ def overlaps_with(load1: MemOp, load2: MemOp, state: angr.SimState) -> bool:
     is true only if the two symbolic addresses _must_ overlap, i.e. there
     is no possible solution where they don't.
     """
+    # If the state is already non-sat, there's no meaning to this check.
+    if not state.solver.satisfiable():
+        return False
+
     addr1 = load1.addr
     sz1 = load1.size
     addr2 = load2.addr
@@ -125,6 +129,10 @@ def get_overlap(load1: MemOp, load2: MemOp, state: angr.SimState):
     Note that we don't handle the case in which the two can overlap
     in more than one way.
     """
+
+    # If the state is already non-sat, there's no meaning to this check.
+    if not state.solver.satisfiable():
+        return None, None, 0
 
     # Consider only these offsets for possible overlaps.
     for i in [0, 1, 2, 4]:

--- a/analyzer/shared/config.py
+++ b/analyzer/shared/config.py
@@ -14,6 +14,7 @@ def init_config(config):
     global_config["SpeculationStopMnemonics"] = {'lfence', 'mfence', 'cpuid'}
     global_config["HalfSpectre"] = False
     global_config["CrashOnExceptions"] = False
+    global_config["AggressiveSpeculation"] = False
 
     # Apply user config.
     for c in config:

--- a/config_all.yaml
+++ b/config_all.yaml
@@ -63,3 +63,10 @@ CrashOnExceptions: False
 # This has consequences on interrupting, e.g., if you analyse only _after_ scanning
 # you won't have any outputted transmission in case of  e.g.timeouts.
 AnalyzeDuringScanning: True
+
+# Should we always visit both sides of a branch, even if the condition is
+# concrete?
+# This is helpful to simulate cases where an attacker might have _indirect_
+# control of a branch speculation, e.g. with out_of_place training or massaging,
+# or when following a trace.
+AggressiveSpeculation: False

--- a/tests/test-cases/unsat_succs/Makefile
+++ b/tests/test-cases/unsat_succs/Makefile
@@ -1,0 +1,8 @@
+all: gadget
+.PHONY: clean
+
+gadget: gadget.s
+	cc -g -O0 -c gadget.s -o gadget
+
+clean:
+	rm -f -r gadget output asm gadgets.csv gadgets-reasoned.csv

--- a/tests/test-cases/unsat_succs/config_all.yaml
+++ b/tests/test-cases/unsat_succs/config_all.yaml
@@ -1,0 +1,35 @@
+controlled_registers:
+  - rax
+  - rbx
+  # Argument registers
+  - rdi
+  - rsi
+  - rdx
+  - rcx
+  - r8
+  - r9
+  # General purpose
+  - r10
+  - r11
+  - r12
+  - r13
+  - r14
+  - r15
+controlled_stack:
+  # 20 64-bit values
+  - start: 0
+    end: 160
+    size: 8
+
+LogLevel: 100
+STLForwarding: True
+
+Z3Timeout: 10000 # ms = 10s
+AnalysisTimeout: 1000 #s
+MaxBB: 10
+DistributeShifts: True
+TaintedFunctionPointers: True
+HalfSpectre: True
+CrashOnExceptions: True
+AggressiveSpeculation: True
+AnalyzeDuringScanning: True

--- a/tests/test-cases/unsat_succs/gadget.s
+++ b/tests/test-cases/unsat_succs/gadget.s
@@ -1,0 +1,35 @@
+.intel_syntax noprefix
+
+setup:
+# Setup chain of pointers  A -> B -> C -> back to A
+mov		qword ptr [0xffffffff81000000], 0xffffffff81000010
+mov		qword ptr [0xffffffff81000010], 0xffffffff81000020
+mov		qword ptr [0xffffffff81000020], 0xffffffff81000000
+
+# Store public value in B+8 and C+8, but not A+8
+mov		qword ptr [0xffffffff81000008], rdi
+mov		qword ptr [0xffffffff81000018], 0xffffffffdeadbeef
+mov		qword ptr [0xffffffff81000028], 0xffffffffcacacafe
+
+# Start from A
+mov rax, 0xffffffff81000000
+mov r12, 0xffffffff81000000
+
+loopy:
+	# Load next element
+	mov	rbx, qword ptr [rax]
+	# Check if it's the head
+	cmp rbx, r12
+    je end
+
+    # If not, read the public values
+    add rbx, 8
+	mov	rcx, qword ptr [rbx]
+	mov	rdx, qword ptr [rcx]
+
+    # Next iter
+    add rax, 0x10
+	jmp loopy
+
+end:
+	jmp		0xdead


### PR DESCRIPTION
:warning: **Do not merge** -> Wait for #28  to be merged

Adds an `AggressiveSpeculation` configuration that also visits _unsatisfiable_ successors, ignoring their constraints.

This is useful when an attacker can cause the speculation with indirect control, e.g. out-of-place training, massaging, presence/absence of user-controlled object is checked etc.

Still needs a bit of testing.

## Testcase explanation

The new testcase mimics a list gadget in the kernel, where every element of the list has a certain type, except the `list_head` which is linked by the last element. If cur == list_head, then the iteration should end the loop, but one extra iteration could be speculatively executed, causing a type confusion that dereferences stuff around the list_head.

This what the `setup` part of the testcase does. This is simulating a situation where we have concrete values, e.g. when following a trace.

![image](https://github.com/user-attachments/assets/e0365d1e-2ab3-41e4-96c8-60cc231f0b18)

Then, it simply iterates over the element. The analyzer correctly outputs a half-spectre gadget (but the printer doesn't understand that it should only print the annotation on last iteration (notice that `loopy` is the same loop body visited 3 times).

![image](https://github.com/user-attachments/assets/54779798-861a-425d-8000-cd081c1c8ec5)
 
